### PR TITLE
Faraday runtime is not reset between requests

### DIFF
--- a/faraday-log-subscriber.gemspec
+++ b/faraday-log-subscriber.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.8'
   spec.add_dependency 'faraday_middleware', '~> 0.9'
   spec.add_dependency 'activesupport', '>= 4.0.0'
+  spec.add_dependency 'actionpack', '>= 4.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/faraday/controller_runtime.rb
+++ b/lib/faraday/controller_runtime.rb
@@ -4,6 +4,11 @@ module Faraday
 
     protected
 
+    def process_action(action, *args)
+      Faraday::LogSubscriber.reset_runtime
+      super
+    end
+
     def append_info_to_payload(payload)
       super
       payload[:faraday_runtime] = Faraday::LogSubscriber.runtime

--- a/test/controller_runtime_test.rb
+++ b/test/controller_runtime_test.rb
@@ -4,7 +4,14 @@ require 'active_support/log_subscriber/test_helper'
 
 class ControllerRuntimeTest < ActionController::TestCase
 
+  ActiveSupport::Deprecation.silence do
+    TestRoutes = ActionDispatch::Routing::RouteSet.new
+    TestRoutes.draw { get ':controller(/:action)' }
+  end
+
   class LogSubscriberController < ActionController::Base
+    include TestRoutes.url_helpers
+
     def zero
       render inline: 'Zero HTTP runtime'
     end
@@ -33,12 +40,7 @@ class ControllerRuntimeTest < ActionController::TestCase
 
   def setup
     super
-
-    ActiveSupport::Deprecation.silence do
-      @routes = ActionDispatch::Routing::RouteSet.new
-      @routes.draw { get ':controller(/:action)' }
-    end
-
+    @routes = TestRoutes
     ActionController::LogSubscriber.attach_to :action_controller
   end
 

--- a/test/controller_runtime_test.rb
+++ b/test/controller_runtime_test.rb
@@ -1,4 +1,90 @@
 require 'test_helper'
+require 'active_support/log_subscriber/test_helper'
 
-class ControllerRuntimeTest < ActiveSupport::TestCase
+
+class ControllerRuntimeTest < ActionController::TestCase
+
+  class LogSubscriberController < ActionController::Base
+    def zero
+      render inline: 'Zero HTTP runtime'
+    end
+
+    def show
+      Faraday::LogSubscriber.runtime += 100
+      render inline: 'Takes 100ms'
+    end
+
+    def redirect
+      Faraday::LogSubscriber.runtime += 100
+      redirect_to 'http://example.com'
+    end
+
+    def faraday_after_render
+      Faraday::LogSubscriber.runtime += 100
+      render inline: 'Hello world'
+      Faraday::LogSubscriber.runtime += 100
+    end
+  end
+
+
+  include ActiveSupport::LogSubscriber::TestHelper
+  tests LogSubscriberController
+
+
+  def setup
+    super
+
+    ActiveSupport::Deprecation.silence do
+      @routes = ActionDispatch::Routing::RouteSet.new
+      @routes.draw { get ':controller(/:action)' }
+    end
+
+    ActionController::LogSubscriber.attach_to :action_controller
+  end
+
+  def teardown
+    super
+
+    ActiveSupport::LogSubscriber.log_subscribers.clear
+    Faraday::LogSubscriber.reset_runtime
+  end
+
+  def set_logger(logger)
+    ActionController::Base.logger = logger
+  end
+
+  def test_runtime_reset_before_requests
+    Faraday::LogSubscriber.runtime += 12345
+    get :zero
+    wait
+
+    assert_equal 2, @logger.logged(:info).size
+    assert_match(/Faraday: 0.0ms\)/, @logger.logged(:info)[1])
+  end
+
+  def test_runtime_reset_between_requests
+    get :show
+    get :show
+    wait
+
+    assert_equal 4, @logger.logged(:info).size
+    assert_match(/Faraday: 100.0ms\)/, @logger.logged(:info)[1])
+    assert_match(/Faraday: 100.0ms\)/, @logger.logged(:info)[3])
+  end
+
+  def test_log_with_faraday_time_when_redirecting
+    get :redirect
+    wait
+
+    assert_equal 3, @logger.logged(:info).size
+    assert_match(/\(Faraday: [\d.]+ms\)/, @logger.logged(:info)[2])
+  end
+
+  def test_include_faraday_time_after_rendering
+    get :faraday_after_render
+    wait
+
+    assert_equal 2, @logger.logged(:info).size
+    assert_match(/Faraday: 200.0ms\)/, @logger.logged(:info)[1])
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,9 @@ require 'bundler/setup'
 require 'active_support'
 require 'active_support/log_subscriber'
 
+require 'action_controller'
+require 'action_controller/log_subscriber'
+
 require 'faraday'
 require 'faraday_middleware'
 


### PR DESCRIPTION
Hi there!

I noticed my app was reporting a faraday runtime for requests which clearly did not make any http requests at all. For example the 2nd request was cached:

```
1. Completed 200 OK in 2723ms (Views: 489.4ms | Faraday: 3024.7ms | ActiveRecord: 0.3ms)
2. Completed 304 Not Modified in 2ms (Faraday: 3024.7ms | ActiveRecord: 0.3ms)
```

and the runtime is added up on each request:

```
1. Completed 200 OK in 3241ms (Views: 850.0ms | Faraday: 1515.8ms | ActiveRecord: 3.9ms)
2. Completed 200 OK in 3198ms (Views: 492.8ms | Faraday: 3382.6ms | ActiveRecord: 0.3ms)
3. Completed 200 OK in 3033ms (Views: 517.7ms | Faraday: 5153.1ms | ActiveRecord: 0.4ms)
```

(which might not be so obvious if you are using a multi-threaded server like puma, because the runtime is stored on each thread separately)

After having a look at the code and comparing it with [AR::Railties::ControllerRuntime](https://github.com/rails/rails/blob/5-0-0/activerecord/lib/active_record/railties/controller_runtime.rb) I noticed the runtime is never reset.

I added some tests for `Faraday::ControllerRuntime` and (hopefully) fixed the bug in this PR. I hope it is ok for you to merge this. Let me know if I forgot something... Thanks! :)
